### PR TITLE
[codex] Unify HELM and VELA public pages language

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <h1 align="center">HELM</h1>
 
 <p align="center">
+  <strong>Hub for Evidence, Logs &amp; Monitoring</strong><br>
   本地项目看板：把项目状态、证据准备、已有文件、本机状态和给 Codex 的说明放在一个清楚的桌面视图里。
 </p>
 
@@ -25,14 +26,14 @@
   ·
   <a href="docs/imports/vela-helm-interface.md">VELA 接口</a>
   ·
-  <a href="https://github.com/Marcus-AI4SS/VELA-Versioned-Evidence-Lifecycle-Architecture">VELA</a>
+  <a href="https://github.com/Marcus-AI4SS/VELA">VELA</a>
   ·
   <a href="PRIVACY.md">隐私</a>
 </p>
 
 ## HELM 是什么
 
-HELM 是本地项目看板。它读取你电脑上的项目状态，并把当前阶段、阻塞点、材料、证据准备度、已有文件、本机状态和给 Codex 的说明集中展示出来。
+HELM = **Hub for Evidence, Logs & Monitoring**。它是本地项目看板，读取你电脑上的项目状态，并把当前阶段、阻塞点、材料、证据准备度、已有文件、本机状态和给 Codex 的说明集中展示出来。
 
 研究推进仍回到 Codex。HELM 不提供聊天、写作、创建项目、一键研究、隐藏任务调度、引用核验或投稿自动化。它只帮助你看清“现在项目处在哪里”和“接下来该把什么交给 Codex”。
 
@@ -55,15 +56,15 @@ HELM 和 VELA 是职责分开的工具，可以协同使用，也可以分别独
 
 | 工具 | 作用 | 能否单独使用 |
 | --- | --- | --- |
-| **VELA** | 为 Codex 准备可携带的本地工作上下文 | 可以 |
-| **HELM** | 读取并展示本地项目状态、证据、文件、本机状态和给 Codex 的说明 | 可以 |
+| **VELA** = Versatile Experiment Lab & Automation | 为 Codex 准备可携带的项目结构、规则、交接模板和本地上下文 | 可以 |
+| **HELM** = Hub for Evidence, Logs & Monitoring | 读取并展示本地项目状态、证据、文件、本机状态和给 Codex 的说明 | 可以 |
 
-没有 VELA 时，HELM 可以显示空状态、公开安全示例或已配置项目状态。启用 VELA 时，HELM 可以读取 VELA 生成的项目上下文。
+没有 VELA 时，HELM 可以显示空状态、公开安全示例或已配置项目状态。启用 VELA 时，HELM 可以读取 VELA 生成的项目上下文。两者共享产品语言，但不共享隐藏内存、云同步或后台任务。
 
 两者共享两个公开接口方向：
 
 - `vela.project.context.v1`：HELM 读取 VELA 项目状态。
-- `helm.codex.handoff.v1`：VELA 读取 HELM 准备的 Codex 继续说明。
+- `helm.codex.handoff.v1`：HELM 准备给 Codex 的继续说明；VELA 只有在用户显式保存或导出时才应写入项目。
 
 接口说明见 [VELA and HELM import interface](docs/imports/vela-helm-interface.md)。
 

--- a/docs/assets/site.css
+++ b/docs/assets/site.css
@@ -206,6 +206,64 @@ h3 {
   margin-top: 30px;
 }
 
+.identity-strip {
+  display: grid;
+  grid-template-columns: minmax(0, 0.86fr) minmax(0, 1.14fr);
+  gap: 18px;
+  align-items: stretch;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: 26px;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 18px 46px rgba(15, 31, 61, 0.06);
+}
+
+.identity-strip h2 {
+  margin: 0;
+  font-size: 1.72rem;
+  line-height: 1.18;
+}
+
+.brand-pair {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.role-card {
+  min-width: 0;
+  padding: 18px;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  background: rgba(255, 255, 255, 0.82);
+}
+
+.role-card.active {
+  border-color: rgba(37, 99, 235, 0.32);
+  background: linear-gradient(145deg, rgba(230, 240, 255, 0.92), rgba(255, 255, 255, 0.9));
+  box-shadow: 0 18px 42px rgba(37, 99, 235, 0.1);
+}
+
+.role-card strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 1.38rem;
+  letter-spacing: 0.14em;
+}
+
+.role-card span {
+  display: block;
+  color: var(--deep);
+  font-weight: 780;
+  line-height: 1.35;
+}
+
+.role-card p {
+  margin: 10px 0 0;
+  color: var(--graphite);
+  line-height: 1.6;
+}
+
 .section-head {
   margin-bottom: 16px;
 }
@@ -294,9 +352,14 @@ footer {
     font-size: 3.2rem;
   }
 
+  .identity-strip,
   .grid-4,
   .grid-3,
   .grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .brand-pair {
     grid-template-columns: 1fr;
   }
 }

--- a/docs/imports.html
+++ b/docs/imports.html
@@ -16,17 +16,17 @@
       <section class="hero">
         <div>
           <div class="eyebrow">Import Interface</div>
-          <h1><span class="sans">Read VELA. Return a bounded handoff.</span></h1>
-          <p>HELM and VELA stay independent. Their integration is a pair of small, inspectable JSON packets stored inside the local research project.</p>
+          <h1><span class="sans">Two products, explicit local files.</span></h1>
+          <p>VELA = Versatile Experiment Lab &amp; Automation. HELM = Hub for Evidence, Logs &amp; Monitoring. They stay independent and exchange inspectable JSON packets inside the local research project.</p>
           <div class="hero-actions">
             <a class="button button-primary" href="./imports/vela-helm-interface.md">Read the contract</a>
-            <a class="button" href="https://github.com/Marcus-AI4SS/VELA-Versioned-Evidence-Lifecycle-Architecture">Open VELA</a>
+            <a class="button" href="https://github.com/Marcus-AI4SS/VELA">Open VELA</a>
           </div>
         </div>
       </section>
       <section class="section grid-2">
-        <article class="card"><h3>VELA to HELM</h3><p><code>vela.project.context.v1</code> lets HELM import paths, status, evidence counts, deliverables, environment health, and handoff readiness.</p></article>
-        <article class="card"><h3>HELM to VELA</h3><p><code>helm.codex.handoff.v1</code> lets VELA store a HELM-prepared Codex handoff under <code>handoffs/</code> for review and continuation.</p></article>
+        <article class="card"><h3>VELA → HELM</h3><p><code>vela.project.context.v1</code> lets HELM read paths, status, evidence counts, files, blockers, and local checks.</p></article>
+        <article class="card"><h3>HELM → Codex / VELA</h3><p><code>helm.codex.handoff.v1</code> is a copyable Codex note. VELA stores it only after explicit user save or export.</p></article>
       </section>
     </main>
   </body>

--- a/docs/imports/vela-helm-interface.md
+++ b/docs/imports/vela-helm-interface.md
@@ -1,8 +1,8 @@
 # HELM and VELA Import Interface
 
-HELM and VELA are separate products. HELM is the local research board. VELA is the portable Codex workflow wrapper. The integration boundary is explicit local files, not app memory, telemetry, or hidden automation.
+HELM and VELA are separate products. HELM is the Hub for Evidence, Logs & Monitoring. VELA is the Versatile Experiment Lab & Automation package for Codex. The integration boundary is explicit local files, not app memory, telemetry, or hidden automation.
 
-## Direction 1: VELA to HELM
+## Direction 1: VELA → HELM
 
 HELM imports a VELA project context packet when a project exposes `vela.project.context.v1`.
 
@@ -65,7 +65,7 @@ Minimal packet:
 
 HELM must treat missing fields as unknown, not as success.
 
-## Direction 2: HELM to VELA
+## Direction 2: HELM → Codex / VELA
 
 VELA imports a HELM handoff packet when HELM prepares a bounded continuation task for Codex.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>HELM · Local Research Board</title>
-    <meta name="description" content="HELM is a local research board for project status, evidence, deliverables, environment health, and Codex handoffs.">
+    <title>HELM · Hub for Evidence, Logs & Monitoring</title>
+    <meta name="description" content="HELM is the Hub for Evidence, Logs &amp; Monitoring: a local command board for research projects.">
     <link rel="stylesheet" href="./assets/site.css">
   </head>
   <body>
@@ -20,40 +20,59 @@
       <section class="hero">
         <div>
           <img class="hero-mark" src="https://raw.githubusercontent.com/Marcus-AI4SS/HELM/main/site/assets/helm-icon.png" alt="HELM command mark">
-          <div class="eyebrow">Local Research Board</div>
+          <div class="eyebrow">Hub for Evidence, Logs & Monitoring</div>
           <h1>HELM</h1>
-          <p>Use HELM as a local dashboard for project status, evidence, deliverables, environment health, and the next Codex handoff. It can run alone, and it can read VELA project context when a VELA environment is available.</p>
+          <p>HELM is the local command board for research projects. It shows status, evidence readiness, existing files, local checks, and the note you should take back to Codex.</p>
           <div class="hero-actions">
             <a class="button button-primary" href="./tutorial.html">First-run guide</a>
             <a class="button button-primary" href="./install.html">Build HELM</a>
-            <a class="button" href="./imports.html">Import VELA</a>
-            <a class="button" href="https://github.com/Marcus-AI4SS/VELA-Versioned-Evidence-Lifecycle-Architecture">VELA repo</a>
+            <a class="button" href="./imports.html">Connect VELA</a>
+            <a class="button" href="https://github.com/Marcus-AI4SS/VELA">VELA repo</a>
             <a class="button" href="https://github.com/Marcus-AI4SS/HELM">GitHub</a>
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-head">
-          <h2>What HELM Gives You</h2>
-          <p>A readable local board over research state without turning the app into a hidden research engine.</p>
+      <section class="section identity-strip">
+        <div>
+          <div class="eyebrow">Shared product language</div>
+          <h2>VELA and HELM are one workflow pair with two separate jobs.</h2>
         </div>
-        <div class="grid-4">
-          <article class="card"><h3>Project Status</h3><p>Show phase, blockers, recent activity, and active project files without moving the project into the app.</p></article>
-          <article class="card"><h3>Evidence Readiness</h3><p>Display evidence levels and source counts without overstating file reads as verified facts.</p></article>
-          <article class="card"><h3>Deliverables</h3><p>Index reports, notes, figures, tables, and handoff outputs that already exist on disk.</p></article>
-          <article class="card"><h3>Codex Handoffs</h3><p>Prepare bounded continuation packets that name task, files, constraints, output, gaps, and review standard.</p></article>
+        <div class="brand-pair">
+          <article class="role-card">
+            <strong>VELA</strong>
+            <span>Versatile Experiment Lab &amp; Automation</span>
+            <p>Prepares portable project structure and bounded Codex work.</p>
+          </article>
+          <article class="role-card active">
+            <strong>HELM</strong>
+            <span>Hub for Evidence, Logs &amp; Monitoring</span>
+            <p>Reads local state and turns it into a clear dashboard.</p>
+          </article>
         </div>
       </section>
 
       <section class="section">
         <div class="section-head">
-          <h2>Two Independent Brands, One Shared Contract</h2>
-          <p>VELA can be installed without HELM. HELM can run without VELA. Together they exchange explicit local files rather than hidden app state.</p>
+          <h2>What HELM Helps You See</h2>
+          <p>HELM keeps the project visible without turning the app into a hidden research engine.</p>
+        </div>
+        <div class="grid-4">
+          <article class="card"><h3>Project Status</h3><p>See the active project, stage, blockers, recent activity, and whether the folder can be read.</p></article>
+          <article class="card"><h3>Evidence Readiness</h3><p>Check what has been read, what is missing, and what still needs Codex review.</p></article>
+          <article class="card"><h3>Files And Outputs</h3><p>Open existing reports, notes, figures, tables, and local check records from one place.</p></article>
+          <article class="card"><h3>Codex Notes</h3><p>Copy a bounded next-step note for Codex without asking HELM to execute the work.</p></article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2>How HELM And VELA Work Together</h2>
+          <p>VELA can be used without HELM. HELM can run without VELA. Together they exchange explicit local files rather than hidden app state.</p>
         </div>
         <div class="grid-2">
-          <article class="card"><h3>VELA to HELM</h3><p>HELM imports <code>vela.project.context.v1</code> to read project paths, status, evidence counts, deliverables, health, and handoff readiness.</p></article>
-          <article class="card"><h3>HELM to VELA</h3><p>VELA imports <code>helm.codex.handoff.v1</code> as a bounded Codex handoff packet under the project <code>handoffs/</code> layer.</p></article>
+          <article class="card"><h3>VELA → HELM</h3><p>VELA writes project context. HELM reads <code>vela.project.context.v1</code> to show paths, status, evidence counts, files, blockers, and local checks.</p></article>
+          <article class="card"><h3>HELM → Codex / VELA</h3><p>HELM prepares <code>helm.codex.handoff.v1</code> as a copyable Codex note. VELA stores it only after an explicit user save or export.</p></article>
         </div>
       </section>
 
@@ -62,12 +81,12 @@
           <h2>Start Here</h2>
         </div>
         <div class="grid-3">
-          <article class="card"><h3>1. Build</h3><p>Install desktop dependencies, run the frontend build, and run the Tauri Rust check.</p></article>
-          <article class="card"><h3>2. Start With The Guide</h3><p>Use the first-run guide when you do not know which page or button to use.</p></article>
-          <article class="card"><h3>3. Hand Off</h3><p>Use the Give to Codex view to prepare a continuation note without executing work automatically.</p></article>
+          <article class="card"><h3>1. Install Or Build</h3><p>Build HELM locally today; packaged public releases will use the same source boundary.</p></article>
+          <article class="card"><h3>2. Open The Guide</h3><p>Use the first-run guide when you do not know which page, button, or project step to use.</p></article>
+          <article class="card"><h3>3. Copy To Codex</h3><p>Use the Codex note view to continue research in Codex with files and constraints named clearly.</p></article>
         </div>
       </section>
-      <footer>HELM is the local research board. VELA is the portable workflow environment.</footer>
+      <footer>VELA = Versatile Experiment Lab &amp; Automation. HELM = Hub for Evidence, Logs &amp; Monitoring.</footer>
     </main>
   </body>
 </html>

--- a/docs/sync-log/vela-helm-sync-2026-04-29.md
+++ b/docs/sync-log/vela-helm-sync-2026-04-29.md
@@ -3,12 +3,12 @@
 ## Scope
 
 - HELM public repository: `Marcus-AI4SS/HELM`
-- VELA repository: `Marcus-AI4SS/VELA-Versioned-Evidence-Lifecycle-Architecture`
-- HELM private/self-use repository verified separately and kept outside the public release lane.
+- VELA repository: `Marcus-AI4SS/VELA`
+- Self-use HELM work was kept outside the public release lane.
 
 ## Boundary Decision
 
-VELA and HELM remain independent products. HELM is the local research board. VELA is the portable workflow environment. The two repositories share visual language, page structure, and import contracts, but neither product controls the other.
+VELA and HELM remain independent products. HELM is the Hub for Evidence, Logs & Monitoring. VELA is the Versatile Experiment Lab & Automation package. The two repositories share visual language, page structure, and import contracts, but neither product controls the other.
 
 ## Synchronized Items
 
@@ -17,9 +17,9 @@ VELA and HELM remain independent products. HELM is the local research board. VEL
 - Import contract added at `docs/imports/vela-helm-interface.md`.
 - Machine-readable schema added at `docs/imports/vela-helm-interface.schema.json`.
 - Shared direction names:
-  - `vela.project.context.v1`: VELA to HELM project context import.
-  - `helm.codex.handoff.v1`: HELM to VELA Codex handoff import.
+  - `vela.project.context.v1`: VELA → HELM project context import.
+  - `helm.codex.handoff.v1`: HELM → Codex / VELA handoff import.
 
 ## Local Note
 
-The private HELM/self-use line is not the public Pages target. Public homepage and Pages work should land in `Marcus-AI4SS/HELM`, not in any private self-use repository.
+The self-use HELM line is not the public Pages target. Public homepage and Pages work should land in `Marcus-AI4SS/HELM`.

--- a/docs/zh/index.html
+++ b/docs/zh/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>HELM · 本地科研看板</title>
-    <meta name="description" content="HELM 是展示项目状态、证据、交付物、环境健康和 Codex 交接的本地科研看板。">
+    <title>HELM · Hub for Evidence, Logs & Monitoring</title>
+    <meta name="description" content="HELM 是本地项目看板，也是 Hub for Evidence, Logs & Monitoring。">
     <link rel="stylesheet" href="../assets/site.css">
   </head>
   <body>
@@ -20,43 +20,72 @@
       <section class="hero">
         <div>
           <img class="hero-mark" src="https://raw.githubusercontent.com/Marcus-AI4SS/HELM/main/site/assets/helm-icon.png" alt="HELM 指向标志">
-          <div class="eyebrow">本地科研看板</div>
+          <div class="eyebrow">Hub for Evidence, Logs &amp; Monitoring</div>
           <h1>HELM</h1>
-          <p>用 HELM 查看项目状态、证据、交付物、环境健康和下一步 Codex 交接。它可以独立运行，也可以在 VELA 环境存在时读取 VELA 项目上下文。</p>
+          <p>HELM 是本地研究项目的指挥看板。它帮你查看项目状态、证据准备、已有文件、本地检查，以及下一步要交给 Codex 的说明。</p>
           <div class="hero-actions">
             <a class="button button-primary" href="./tutorial.html">零基础教程</a>
             <a class="button button-primary" href="../install.html">构建 HELM</a>
-            <a class="button" href="../imports.html">导入 VELA</a>
-            <a class="button" href="https://github.com/Marcus-AI4SS/VELA-Versioned-Evidence-Lifecycle-Architecture">VELA 仓库</a>
+            <a class="button" href="../imports.html">连接 VELA</a>
+            <a class="button" href="https://github.com/Marcus-AI4SS/VELA">VELA 仓库</a>
             <a class="button" href="https://github.com/Marcus-AI4SS/HELM">GitHub</a>
           </div>
         </div>
       </section>
 
-      <section class="section">
-        <div class="section-head">
-          <h2>HELM 提供什么</h2>
-          <p>在不把 app 变成隐藏研究执行器的前提下，给本地研究状态一个可读看板。</p>
+      <section class="section identity-strip">
+        <div>
+          <div class="eyebrow">统一产品语言</div>
+          <h2>VELA 和 HELM 是一套工作流里的两个分工，不是同一个工具。</h2>
         </div>
-        <div class="grid-4">
-          <article class="card"><h3>项目状态</h3><p>展示阶段、阻塞、近期活动和活跃文件，不把项目迁入 app 内部。</p></article>
-          <article class="card"><h3>证据准备度</h3><p>展示证据等级和来源计数，不把文件读取夸大成事实核验。</p></article>
-          <article class="card"><h3>交付物</h3><p>索引磁盘上已有的报告、笔记、图表和交接输出。</p></article>
-          <article class="card"><h3>Codex 交接</h3><p>准备包含任务、文件、约束、输出、缺口和复核标准的有边界交接包。</p></article>
+        <div class="brand-pair">
+          <article class="role-card">
+            <strong>VELA</strong>
+            <span>Versatile Experiment Lab &amp; Automation</span>
+            <p>准备可携带的项目结构和有边界的 Codex 工作。</p>
+          </article>
+          <article class="role-card active">
+            <strong>HELM</strong>
+            <span>Hub for Evidence, Logs &amp; Monitoring</span>
+            <p>读取本地状态，并把它变成清楚的项目看板。</p>
+          </article>
         </div>
       </section>
 
       <section class="section">
         <div class="section-head">
-          <h2>两个独立品牌，一套共享契约</h2>
+          <h2>HELM 帮你看什么</h2>
+          <p>HELM 只负责把项目看清楚，不把 app 变成隐藏研究执行器。</p>
+        </div>
+        <div class="grid-4">
+          <article class="card"><h3>项目状态</h3><p>查看当前项目、阶段、阻塞、最近活动，以及项目文件夹能不能读取。</p></article>
+          <article class="card"><h3>证据准备</h3><p>看哪些已经读到、哪些缺失、哪些还需要回到 Codex 继续检查。</p></article>
+          <article class="card"><h3>文件和产物</h3><p>从一个地方打开已有报告、笔记、图表、表格和本地检查记录。</p></article>
+          <article class="card"><h3>给 Codex 的说明</h3><p>复制有边界的下一步说明，不让 HELM 自动执行研究任务。</p></article>
+        </div>
+      </section>
+
+      <section class="section">
+        <div class="section-head">
+          <h2>HELM 和 VELA 怎么协作</h2>
           <p>VELA 不需要 HELM 也能安装使用。HELM 不需要 VELA 也能运行。组合使用时，两者通过显式本地文件交换状态，而不是依赖隐藏 app 状态。</p>
         </div>
         <div class="grid-2">
-          <article class="card"><h3>VELA 到 HELM</h3><p>HELM 导入 <code>vela.project.context.v1</code>，读取项目路径、状态、证据计数、交付物、环境健康和交接准备度。</p></article>
-          <article class="card"><h3>HELM 到 VELA</h3><p>VELA 导入 <code>helm.codex.handoff.v1</code>，作为有边界的 Codex 交接包存入项目 <code>handoffs/</code> 层。</p></article>
+          <article class="card"><h3>VELA → HELM</h3><p>VELA 写出项目上下文。HELM 读取 <code>vela.project.context.v1</code>，展示路径、状态、证据计数、文件、阻塞和本地检查。</p></article>
+          <article class="card"><h3>HELM → Codex / VELA</h3><p>HELM 准备可复制的 <code>helm.codex.handoff.v1</code> 说明。只有用户显式保存或导出时，VELA 才应写入项目。</p></article>
         </div>
       </section>
-      <footer>HELM 是本地科研看板。VELA 是可移植科研工作流环境。</footer>
+      <section class="section">
+        <div class="section-head">
+          <h2>从这里开始</h2>
+        </div>
+        <div class="grid-3">
+          <article class="card"><h3>1. 安装或构建</h3><p>现在可以本地构建 HELM；之后公开安装包也会沿用同样的边界。</p></article>
+          <article class="card"><h3>2. 打开教程</h3><p>如果不知道先点哪里，就从零基础教程开始。</p></article>
+          <article class="card"><h3>3. 复制给 Codex</h3><p>在“给 Codex 的说明”里复制下一步，把研究推进放回 Codex。</p></article>
+        </div>
+      </section>
+      <footer>VELA = Versatile Experiment Lab &amp; Automation。HELM = Hub for Evidence, Logs &amp; Monitoring。</footer>
     </main>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- aligns HELM README and Pages with the shared VELA / HELM language
- adds the role strip: VELA = Versatile Experiment Lab & Automation, HELM = Hub for Evidence, Logs & Monitoring
- updates import pages and sync wording so HELM reads context and prepares copyable Codex notes without hidden coupling

## Validation

- git diff --check
- stale brand/private wording scan returned 0 findings
- HTML parser smoke for docs pages
